### PR TITLE
8253418: ZGC: Use pd_ prefix to denote platform dependent code

### DIFF
--- a/src/hotspot/os/bsd/gc/z/zLargePages_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zLargePages_bsd.cpp
@@ -25,7 +25,7 @@
 #include "gc/z/zLargePages.hpp"
 #include "runtime/globals.hpp"
 
-void ZLargePages::initialize_platform() {
+void ZLargePages::pd_initialize() {
   if (UseLargePages) {
     _state = Explicit;
   } else {

--- a/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zNUMA_bsd.cpp
@@ -24,7 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/z/zNUMA.hpp"
 
-void ZNUMA::initialize_platform() {
+void ZNUMA::pd_initialize() {
   _enabled = false;
 }
 

--- a/src/hotspot/os/linux/gc/z/zLargePages_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zLargePages_linux.cpp
@@ -25,7 +25,7 @@
 #include "gc/z/zLargePages.hpp"
 #include "runtime/globals.hpp"
 
-void ZLargePages::initialize_platform() {
+void ZLargePages::pd_initialize() {
   if (UseLargePages) {
     if (UseTransparentHugePages) {
       _state = Transparent;

--- a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
@@ -29,7 +29,7 @@
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 
-void ZNUMA::initialize_platform() {
+void ZNUMA::pd_initialize() {
   _enabled = UseNUMA;
 }
 

--- a/src/hotspot/os/posix/gc/z/zInitialize_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zInitialize_posix.cpp
@@ -24,6 +24,6 @@
 #include "precompiled.hpp"
 #include "gc/z/zInitialize.hpp"
 
-void ZInitialize::initialize_os() {
+void ZInitialize::os_initialize() {
   // Does nothing
 }

--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -29,7 +29,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 
-void ZVirtualMemoryManager::initialize_os() {
+void ZVirtualMemoryManager::os_initialize() {
   // Does nothing
 }
 

--- a/src/hotspot/os/windows/gc/z/zInitialize_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zInitialize_windows.cpp
@@ -25,6 +25,6 @@
 #include "gc/z/zInitialize.hpp"
 #include "gc/z/zSyscall_windows.hpp"
 
-void ZInitialize::initialize_os() {
+void ZInitialize::os_initialize() {
   ZSyscall::initialize();
 }

--- a/src/hotspot/os/windows/gc/z/zLargePages_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zLargePages_windows.cpp
@@ -24,6 +24,6 @@
 #include "precompiled.hpp"
 #include "gc/z/zLargePages.hpp"
 
-void ZLargePages::initialize_platform() {
+void ZLargePages::pd_initialize() {
   _state = Disabled;
 }

--- a/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zNUMA_windows.cpp
@@ -24,7 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/z/zNUMA.hpp"
 
-void ZNUMA::initialize_platform() {
+void ZNUMA::pd_initialize() {
   _enabled = false;
 }
 

--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -87,7 +87,7 @@ static void grow_from_back_callback(const ZMemory* area, size_t size) {
   coalesce_into_one_placeholder(area->start(), area->size() + size);
 }
 
-void ZVirtualMemoryManager::initialize_os() {
+void ZVirtualMemoryManager::os_initialize() {
   // Each reserved virtual memory address area registered in _manager is
   // exactly covered by a single placeholder. Callbacks are installed so
   // that whenever a memory area changes, the corresponding placeholder

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -52,5 +52,5 @@ ZInitialize::ZInitialize(ZBarrierSet* barrier_set) {
   ZLargePages::initialize();
   ZBarrierSet::set_barrier_set(barrier_set);
 
-  initialize_os();
+  os_initialize();
 }

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -30,7 +30,7 @@ class ZBarrierSet;
 
 class ZInitialize {
 private:
-  void initialize_os();
+  void os_initialize();
 
 public:
   ZInitialize(ZBarrierSet* barrier_set);

--- a/src/hotspot/share/gc/z/zLargePages.cpp
+++ b/src/hotspot/share/gc/z/zLargePages.cpp
@@ -29,7 +29,7 @@
 ZLargePages::State ZLargePages::_state;
 
 void ZLargePages::initialize() {
-  initialize_platform();
+  pd_initialize();
 
   log_info_p(gc, init)("Memory: " JULONG_FORMAT "M", os::physical_memory() / M);
   log_info_p(gc, init)("Large Page Support: %s", to_string());

--- a/src/hotspot/share/gc/z/zLargePages.hpp
+++ b/src/hotspot/share/gc/z/zLargePages.hpp
@@ -36,7 +36,7 @@ private:
 
   static State _state;
 
-  static void initialize_platform();
+  static void pd_initialize();
 
 public:
   static void initialize();

--- a/src/hotspot/share/gc/z/zNUMA.cpp
+++ b/src/hotspot/share/gc/z/zNUMA.cpp
@@ -28,7 +28,7 @@
 bool ZNUMA::_enabled;
 
 void ZNUMA::initialize() {
-  initialize_platform();
+  pd_initialize();
 
   log_info_p(gc, init)("NUMA Support: %s", to_string());
   if (_enabled) {

--- a/src/hotspot/share/gc/z/zNUMA.hpp
+++ b/src/hotspot/share/gc/z/zNUMA.hpp
@@ -30,7 +30,7 @@ class ZNUMA : public AllStatic {
 private:
   static bool _enabled;
 
-  static void initialize_platform();
+  static void pd_initialize();
 
 public:
   static void initialize();

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -49,7 +49,7 @@ ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity) :
   }
 
   // Initialize OS specific parts
-  initialize_os();
+  os_initialize();
 
   // Successfully initialized
   _initialized = true;

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -51,7 +51,7 @@ private:
   bool           _initialized;
 
   // OS specific implementation
-  void initialize_os();
+  void os_initialize();
   bool os_reserve(uintptr_t addr, size_t size);
   void os_unreserve(uintptr_t addr, size_t size);
 


### PR DESCRIPTION
Trivial patch to rename ZGC's platform dependent functions.