### PR TITLE
8264271: Avoid creating non_oop_word oops

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -140,7 +140,7 @@ void CompiledIC::internal_set_ic_destination(address entry_point, bool is_icstub
     return;
   }
 
-  if (cache == NULL)  cache = (void*)Universe::non_oop_word();
+  if (cache == NULL)  cache = Universe::non_oop_word();
 
   set_data((intptr_t)cache);
 }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1026,9 +1026,9 @@ inline void nmethod::initialize_immediate_oop(oop* dest, jobject handle) {
   if (handle == NULL ||
       // As a special case, IC oops are initialized to 1 or -1.
       handle == (jobject) Universe::non_oop_word()) {
-    (*dest) = cast_to_oop(handle);
+    *(void**)dest = handle;
   } else {
-    (*dest) = JNIHandles::resolve_non_null(handle);
+    *dest = JNIHandles::resolve_non_null(handle);
   }
 }
 
@@ -2616,7 +2616,7 @@ void nmethod::print_oops(outputStream* st) {
     for (oop* p = oops_begin(); p < oops_end(); p++) {
       Disassembler::print_location((unsigned char*)p, (unsigned char*)oops_begin(), (unsigned char*)oops_end(), st, true, false);
       st->print(PTR_FORMAT " ", *((uintptr_t*)p));
-      if (*p == Universe::non_oop_word()) {
+      if (Universe::contains_non_oop_word(p)) {
         st->print_cr("NON_OOP");
         continue;  // skip non-oops
       }
@@ -2712,6 +2712,36 @@ void nmethod::print_nul_chk_table() {
   ImplicitExceptionTable(this).print(code_begin());
 }
 
+void nmethod::print_recorded_oop(int log_n, int i) {
+  void* value;
+
+  if (i == 0) {
+    value = NULL;
+  } else {
+    // Be careful around non-oop words. Don't create an oop
+    // with that value, or it will assert in verification code.
+    if (Universe::contains_non_oop_word(oop_addr_at(i))) {
+      value = Universe::non_oop_word();
+    } else {
+      value = oop_at(i);
+    }
+  }
+
+  tty->print("#%*d: " INTPTR_FORMAT " ", log_n, i, p2i(value));
+
+  if (value == Universe::non_oop_word()) {
+    tty->print("non-oop word");
+  } else {
+    if (value == 0) {
+      tty->print("NULL-oop");
+    } else {
+      oop_at(i)->print_value_on(tty);
+    }
+  }
+
+  tty->cr();
+}
+
 void nmethod::print_recorded_oops() {
   const int n = oops_count();
   const int log_n = (n<10) ? 1 : (n<100) ? 2 : (n<1000) ? 3 : (n<10000) ? 4 : 6;
@@ -2719,16 +2749,7 @@ void nmethod::print_recorded_oops() {
   if (n > 0) {
     tty->cr();
     for (int i = 0; i < n; i++) {
-      oop o = oop_at(i);
-      tty->print("#%*d: " INTPTR_FORMAT " ", log_n, i, p2i(o));
-      if ((void*)o == Universe::non_oop_word()) {
-        tty->print("non-oop word");
-      } else if (o == NULL) {
-        tty->print("NULL-oop");
-      } else {
-        o->print_value_on(tty);
-      }
-      tty->cr();
+      print_recorded_oop(log_n, i);
     }
   } else {
     tty->print_cr(" <list empty>");

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -671,6 +671,7 @@ public:
   void print_native_invokers();
   void print_handler_table();
   void print_nul_chk_table();
+  void print_recorded_oop(int log_n, int index);
   void print_recorded_oops();
   void print_recorded_metadata();
 

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -541,10 +541,11 @@ oop* oop_Relocation::oop_addr() {
 
 
 oop oop_Relocation::oop_value() {
-  oop v = *oop_addr();
   // clean inline caches store a special pseudo-null
-  if (v == Universe::non_oop_word())  v = NULL;
-  return v;
+  if (Universe::contains_non_oop_word(oop_addr())) {
+    return NULL;
+  }
+  return *oop_addr();
 }
 
 

--- a/src/hotspot/share/gc/z/zNMethod.cpp
+++ b/src/hotspot/share/gc/z/zNMethod.cpp
@@ -219,7 +219,7 @@ void ZNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl) {
     oop* const begin = nm->oops_begin();
     oop* const end = nm->oops_end();
     for (oop* p = begin; p < end; p++) {
-      if (*p != Universe::non_oop_word()) {
+      if (!Universe::contains_non_oop_word(p)) {
         cl->do_oop(p);
       }
     }
@@ -232,7 +232,7 @@ void ZNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl) {
     oop** const begin = oops->immediates_begin();
     oop** const end = oops->immediates_end();
     for (oop** p = begin; p < end; p++) {
-      if (**p != Universe::non_oop_word()) {
+      if (*p != Universe::non_oop_word()) {
         cl->do_oop(*p);
       }
     }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -716,6 +716,10 @@ void* Universe::non_oop_word() {
   return (void*)_non_oop_bits;
 }
 
+bool Universe::contains_non_oop_word(void* p) {
+  return *(void**)p == non_oop_word();
+}
+
 static void initialize_global_behaviours() {
   CompiledICProtectionBehaviour::set_current(new DefaultICProtectionBehaviour());
 }

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -367,7 +367,8 @@ class Universe: AllStatic {
   // array; this should trigger relocation in a sliding compaction collector.
   debug_only(static bool release_fullgc_alot_dummy();)
   // The non-oop pattern (see compiledIC.hpp, etc)
-  static void*   non_oop_word();
+  static void*         non_oop_word();
+  static bool contains_non_oop_word(void* p);
 
   // Oop verification (see MacroAssembler::verify_oop)
   static uintptr_t verify_oop_mask()          PRODUCT_RETURN0;


### PR DESCRIPTION
Some parts of the JVM puts an marker to show that a location does not contain a valid oop. The code that handles this typically look like this:

oop* p = ...
if (*p != Universe::non_oop_word())

This means that sometimes the *p will create an oop that contains the non_oop_word. This makes it problematic to add stricter oop verification. I propose that we add a new function that checks the value of locations without converting it to an oop. 